### PR TITLE
Fine with 10 failures

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -339,13 +339,21 @@ if [ 'true' = "$DEPLOYMENT_OVERVIEW" ]; then
 
   h2  "Deploying application '$APPLICATION_NAME' on deployment group '$DEPLOYMENT_GROUP'"
 
+  FAILURE_COUNTER=0
   while :
     do
       sleep 5
       DEPLOYMENT_GET_OUTPUT=$($DEPLOYMENT_GET 2>&1 > /tmp/$DEPLOYMENT_ID)
       if [ $? -ne 0 ]; then
+        warn "DEPLOYMENT_GET failed, will keep retrying"
+        FAILURE_COUNTER=$((FAILURE_COUNTER + 1))
         printf "\n"
         warn "$DEPLOYMENT_GET_OUTPUT"
+        continue
+      fi
+
+      if [ $FAILURE_COUNTER -eq 10 ]; then
+        warn "Deployment fetch failed 10 times. Giving up"
         error "Deployment of application '$APPLICATION_NAME' on deployment group '$DEPLOYMENT_GROUP' failed"
         exit 1
       fi

--- a/run.sh
+++ b/run.sh
@@ -345,7 +345,7 @@ if [ 'true' = "$DEPLOYMENT_OVERVIEW" ]; then
       DEPLOYMENT_GET_OUTPUT=$($DEPLOYMENT_GET 2>&1 > /tmp/$DEPLOYMENT_ID)
       if [ $? -ne 0 ]; then
         printf "\n"
-        warn "$DEPLOYMENT_OUTPUT"
+        warn "$DEPLOYMENT_GET_OUTPUT"
         error "Deployment of application '$APPLICATION_NAME' on deployment group '$DEPLOYMENT_GROUP' failed"
         exit 1
       fi

--- a/wercker-step.yml
+++ b/wercker-step.yml
@@ -1,5 +1,5 @@
 name: aws-code-deploy
-version: 0.0.24
+version: 0.0.25
 description: Deploy applications with AWS Code Deploy
 keywords:
   - aws


### PR DESCRIPTION
Filed on the wrong repo, but I'll leave this open regardless.

This PR adds 2 things:

1. Fixes DEPLOYMENT_GET error reporting
2. Allows for 10 failures in DEPLOYMENT_GET. We've noticed AWS CD API timing out on that call, and it made sense to wait till 10 errors before giving up.

